### PR TITLE
Refactor BlockchainNode into smaller modules

### DIFF
--- a/src/content/blockhain-simulator/services/BlockchainNode.ts
+++ b/src/content/blockhain-simulator/services/BlockchainNode.ts
@@ -1,11 +1,11 @@
-import { uid, clone, sha256, generateKeyPair, sign, verify } from '../utils/crypto';
+import { uid, clone } from '../utils/crypto';
 import { Transaction } from '../models/Transaction';
 import { Block } from '../models/Block';
-import { ContractEngine } from './ContractEngine';
-import { PoWMiner } from './PoWMiner';
 import { PoAConsensus } from './PoAConsensus';
 import { LocalStorageBus } from './LocalStorageBus';
 import { addActivityLog } from '../utils/log';
+import * as NodePublic from './node/public';
+import * as NodePrivate from './node/private';
 
 interface BlockchainNodeMessage {
   type: string,
@@ -116,138 +116,45 @@ export class BlockchainNode {
   }
 
   async createTx(payload: any, to: string = '', amount: number = 0): Promise<string> {
-    const tx = new Transaction({
-      type: 'transfer',
-      from: this.id,
-      payload,
-      to,
-      amount
-    });
-
-    // Sign the transaction
-    await this._signTransaction(tx);
-
-    this.mempool.push(tx);
-    this._emit('mempool');
-    this.bus.broadcast({ type: 'TX', from: this.id, tx });
-    return tx.id;
+    return NodePublic.createTx(this, payload, to, amount);
   }
 
 
   async deployContract(code: string): Promise<string> {
-    const tx = new Transaction({
-      type: 'deploy',
-      from: this.id,
-      payload: code,
-      to: '' // no recipient for deploy
-    });
-
-    // Sign the transaction
-    await this._signTransaction(tx);
-
-    this.mempool.push(tx);
-    this._emit('mempool');
-    this.bus.broadcast({ type: 'TX', from: this.id, tx });
-    return tx.id;
+    return NodePublic.deployContract(this, code);
   }
 
   async callContract(address: string, input: any): Promise<string> {
-    const tx = new Transaction({
-      type: 'call',
-      from: this.id,
-      to: address,
-      payload: input
-    });
-
-    // Sign the transaction
-    await this._signTransaction(tx);
-
-    this.mempool.push(tx);
-    this._emit('mempool');
-    this.bus.broadcast({ type: 'TX', from: this.id, tx });
-    return tx.id;
+    return NodePublic.callContract(this, address, input);
   }
 
-  // Listen for difficulty updates from the UI
   updateDifficulty(newDifficulty: number) {
-    this.difficulty = newDifficulty;
-    localStorage.setItem('networkDifficulty', newDifficulty.toString());
-    this.bus.broadcast({ type: 'DIFFICULTY_UPDATE', from: this.id, difficulty: newDifficulty });
+    NodePublic.updateDifficulty(this, newDifficulty);
     addActivityLog('network', `Node ${this.id} updated difficulty to ${newDifficulty}`);
   }
 
   startMining(difficulty?: number) {
-    if (this.mining) return;
-
-    // Use network difficulty if not specified
-    const targetDifficulty = difficulty || this.difficulty;
-
-    // Broadcast difficulty update if it's different
-    if (targetDifficulty !== this.difficulty) {
-      this.updateDifficulty(targetDifficulty);
-    }
-
-    this.mining = true;
-    this.minerAbort = { killed: false };
-    this._mineLoop(targetDifficulty);
+    NodePublic.startMining(this, difficulty);
   }
 
   stopMining() {
-    if (this.mining) {
-      this.minerAbort.killed = true; this.mining = false;
-    }
+    NodePublic.stopMining(this);
   }
 
   resetBlockchain() {
-    // Stop mining if active
-    if (this.mining) {
-      this.stopMining();
-    }
-
-    // Clear local state
-    this.chain = [];
-    this.mempool = [];
-    this.contracts = {};
-
-    // Clear localStorage
-    localStorage.removeItem('chain');
-    localStorage.removeItem('networkDifficulty');
-
-    // Reset difficulty to default
-    this.difficulty = 4;
-    localStorage.setItem('networkDifficulty', '4');
-
-    // Broadcast reset to all peers
-    this.bus.broadcast({
-      type: 'BLOCKCHAIN_RESET',
-      from: this.id
-    });
-
-    // Emit state changes
-    this._emit('chain');
-    this._emit('mempool');
-
+    NodePublic.resetBlockchain(this);
     addActivityLog('network', `Node ${this.id} initiated blockchain reset`);
   }
 
   proposeValidator(nodeId: string) {
     addActivityLog('governance', `Node ${this.id} proposed ${nodeId} as new validator`);
-    this.bus.broadcast({
-      type: 'PROPOSE_VALIDATOR',
-      from: this.id,
-      nodeId: nodeId
-    });
+    NodePublic.proposeValidator(this, nodeId);
   }
 
   voteValidator(nodeId: string, approve: boolean) {
     const action = approve ? 'approved' : 'rejected';
     addActivityLog('governance', `Node ${this.id} ${action} validator proposal for ${nodeId}`);
-    this.bus.broadcast({
-      type: 'VOTE_VALIDATOR',
-      from: this.id,
-      nodeId: nodeId,
-      approve: approve
-    });
+    NodePublic.voteValidator(this, nodeId, approve);
   }
 
 
@@ -258,125 +165,11 @@ export class BlockchainNode {
   /* ============================================================================ */
 
   async createMaliciousTx(type: 'invalid_signature' | 'double_spend' | 'invalid_balance' | 'malformed_data' | 'replay_attack'): Promise<string> {
-    let tx: Transaction;
-
-    switch (type) {
-      case 'invalid_signature':
-        tx = new Transaction({
-          type: 'transfer',
-          from: this.id,
-          to: Array.from(this.peers)[1] || 'unknown',
-          amount: 10,
-          payload: 'Malicious transaction with invalid signature'
-        });
-        // Sign with wrong private key
-        tx.signature = await sign(`fake_data`, 'wrong_private_key');
-        tx.publicKey = this.keyPair.publicKey;
-        break;
-
-      case 'double_spend':
-        tx = new Transaction({
-          type: 'transfer',
-          from: this.id,
-          to: Array.from(this.peers)[1] || 'unknown',
-          amount: this.balances[this.id] + 100, // Spend more than available
-          payload: 'Double spend attempt'
-        });
-        await this._signTransaction(tx);
-        break;
-
-      case 'invalid_balance':
-        tx = new Transaction({
-          type: 'transfer',
-          from: this.id,
-          to: Array.from(this.peers)[1] || 'unknown',
-          amount: -50, // Negative amount
-          payload: 'Invalid negative amount'
-        });
-        await this._signTransaction(tx);
-        break;
-
-      case 'malformed_data':
-        tx = new Transaction({
-          type: 'transfer',
-          from: this.id,
-          to: Array.from(this.peers)[1] || 'unknown',
-          amount: 10,
-          payload: { malicious: true, script: '<script>alert("xss")</script>' }
-        });
-        await this._signTransaction(tx);
-        // Corrupt the transaction data after signing
-        tx.payload = null;
-        break;
-
-      case 'replay_attack':
-        // Find an existing transaction and replay it
-        const existingTx = this.chain.flatMap(block => block.transactions)[0];
-        if (existingTx) {
-          tx = new Transaction({
-            type: existingTx.type,
-            from: existingTx.from,
-            to: existingTx.to,
-            amount: existingTx.amount,
-            payload: existingTx.payload
-          });
-          // Use the old signature
-          tx.signature = existingTx.signature;
-          tx.publicKey = existingTx.publicKey;
-          tx.timestamp = existingTx.timestamp; // Same timestamp for replay
-        } else {
-          // Fallback if no existing transactions
-          tx = new Transaction({
-            type: 'transfer',
-            from: this.id,
-            to: Array.from(this.peers)[1] || 'unknown',
-            amount: 10,
-            payload: 'Replay attack attempt'
-          });
-          await this._signTransaction(tx);
-        }
-        break;
-
-      default:
-        throw new Error(`Unknown malicious transaction type: ${type}`);
-    }
-
-    // Broadcast the malicious transaction
-    this.bus.broadcast({ type: 'TX', from: this.id, tx });
-    addActivityLog('security', `Node ${this.id} sent malicious transaction: ${type}`);
-
-    return tx.id;
+    return NodePublic.createMaliciousTx(this, type);
   }
 
   async createMaliciousBlock(): Promise<void> {
-    if (!this.mining) {
-      addActivityLog('security', 'Cannot create malicious block - not mining');
-      return;
-    }
-
-    // Create a block with invalid transactions
-    const maliciousTx = new Transaction({
-      type: 'transfer',
-      from: 'fake_node',
-      to: this.id,
-      amount: 1000000, // Huge amount
-      payload: 'Malicious block creation'
-    });
-
-    const block = new Block({
-      index: this.chain.length,
-      prevHash: 'INVALID_PREV_HASH', // Wrong previous hash
-      proposer: this.id,
-      difficulty: 1, // Low difficulty
-      transactions: [maliciousTx],
-    });
-
-    // Force a hash without proper mining
-    block.hash = await sha256('malicious_block_' + Date.now());
-    block.nonce = 0;
-
-    this.bus.broadcast({ type: 'NEW_BLOCK', from: this.id, block });
-    addActivityLog('security', `Node ${this.id} sent malicious block with invalid data`);
+    NodePublic.createMaliciousBlock(this);
   }
 
 
@@ -387,377 +180,81 @@ export class BlockchainNode {
   /* ============================================================================ */
 
   _emit(evt: string) {
-    for (const f of this.listeners[evt]) f(this.getState());
+    NodePrivate.emit(this, evt);
   }
 
   private _loadOrGenerateKeys(): { publicKey: string, privateKey: string } {
-    const stored = localStorage.getItem(`keys_${this.id}`);
-    if (stored) {
-      return JSON.parse(stored);
-    }
-
-    const keyPair = generateKeyPair();
-    localStorage.setItem(`keys_${this.id}`, JSON.stringify(keyPair));
-    return keyPair;
+    return NodePrivate.loadOrGenerateKeys(this);
   }
 
   private async _signTransaction(tx: Transaction): Promise<void> {
-    const txData = `${tx.type}|${tx.from}|${tx.to}|${tx.amount}|${JSON.stringify(tx.payload)}|${tx.timestamp}`;
-    tx.signature = await sign(txData, this.keyPair.privateKey);
-    tx.publicKey = this.keyPair.publicKey;
+    await NodePrivate.signTransaction(this, tx);
   }
 
 
   async _mineLoop(diff: number) {
-    while (this.mining && !this.minerAbort.killed) {
-      if (this.mempool.length === 0) {
-        await new Promise(r => setTimeout(r, 500));
-        continue;
-      }
-
-      const block = new Block({
-        index: this.chain.length,
-        prevHash: this.chain.length ? this.chain[this.chain.length - 1].hash : 'GENESIS',
-        proposer: this.id,
-        difficulty: diff,
-        transactions: clone(this.mempool),
-      });
-
-      const ok = await PoWMiner.mine(block, diff, this.minerAbort);
-      if (!ok) {
-        // If mining was aborted due to new block, restart the loop
-        if (this.mining && this.minerAbort.killed) {
-          this.minerAbort = { killed: false };
-          continue; // Start mining the next block
-        }
-        break; // mining stopped manually
-      }
-
-      // mined!
-      this.bus.broadcast({ type: 'NEW_BLOCK', from: this.id, block });
-      // Vote for own block immediately
-      this.consensus.propose(block);
-      // wait a bit to avoid piling up mined blocks
-      await new Promise(r => setTimeout(r, 200));
-    }
+    await NodePrivate.mineLoop(this, diff);
   }
 
   private async _commitBlock(block: Block): Promise<void> {
-    // prevent duplicates
-    if (this.chain.find(b => b.hash === block.hash)) return;
-
-    // Verify all transactions in the block
-    for (const tx of block.transactions) {
-      const isValid = await this._verifyTransaction(tx);
-      if (!isValid) {
-        addActivityLog('security', `Block ${block.hash} rejected - contains invalid transaction ${tx.id}`);
-        return;
-      }
-    }
-
-    // Stop mining when a new block is committed
-    if (this.mining) {
-      this.minerAbort.killed = true;
-    }
-
-    // remove txs
-    const ids = new Set(block.transactions.map(t => t.id));
-    this.mempool = this.mempool.filter(t => !ids.has(t.id));
-
-    // contracts and balances processing
-    for (const tx of block.transactions) {
-      if (tx.type === 'deploy') {
-        const c = ContractEngine.deploy(tx.payload);
-        this.contracts[c.address] = c;
-        addActivityLog('contract', `Deployed contract ${c.address} with code: ${tx.payload.slice(0, 20)}...`);
-      } else if (tx.type === 'call') {
-        const c = this.contracts[tx.to];
-        if (c) ContractEngine.call(c, tx.payload, this.contracts);
-        addActivityLog('contract', `Called contract ${tx.to} with input: ${JSON.stringify(tx.payload)}`);
-      } else if (tx.type === 'transfer') {
-        if (!this.balances[tx.from]) this.balances[tx.from] = 0;
-        if (!this.balances[tx.to]) this.balances[tx.to] = 0;
-        if (this.balances[tx.from] >= tx.amount) {
-          this.balances[tx.from] -= tx.amount;
-          this.balances[tx.to] += tx.amount;
-        }
-      }
-    }
-
-    this.chain.push(block);
-
-    if (this.chain.length > 100) {
-      addActivityLog('network', `Node ${this.id} trimmed blockchain to last 100 blocks`);
-      this.chain = this.chain.slice(-100);
-    }
-
-    localStorage.setItem('chain', JSON.stringify(this.chain));
-    localStorage.setItem('balances', JSON.stringify(this.balances));
-    this._emit('chain');
-    this._emit('mempool');
-    this._emit('balances');
-    this._emit('contracts');
-
-    // Restart mining if it was active
-    if (this.mining) {
-      this.minerAbort = { killed: false };
-    }
+    await NodePrivate.commitBlock(this, block);
   }
 
 
   private _handleHello(msg: BlockchainNodeMessage) {
-    this.peers.add(msg.from);
-    this.peerLastSeen.set(msg.from, Date.now());
-    this._emit('peers');
-    if (msg.from !== this.id) {
-      this.bus.broadcast({ type: 'HELLO_ACK', from: this.id, to: msg.from });
-    }
-    addActivityLog('peer', `New peer ${msg.from} joined the network`);
+    NodePrivate.handleHello(this, msg);
   }
 
   private _handleHelloAck(msg: BlockchainNodeMessage) {
-    if (msg.to === this.id) {
-      this.peers.add(msg.from);
-      this.peerLastSeen.set(msg.from, Date.now());
-      this._emit('peers');
-    }
-    addActivityLog('network', `Node ${this.id} acknowledged peer ${msg.from}`);
+    NodePrivate.handleHelloAck(this, msg);
   }
 
 
   private _handleGoodbye(msg: BlockchainNodeMessage) {
-    this.peers.delete(msg.from);
-    this.peerLastSeen.delete(msg.from);
-    this._emit('peers');
-    addActivityLog('peer', `Peer ${msg.from} left the network`);
+    NodePrivate.handleGoodbye(this, msg);
   }
 
   private _handleHeartbeat(msg: BlockchainNodeMessage) {
-    this.peers.add(msg.from);
-    this.peerLastSeen.set(msg.from, Date.now());
+    NodePrivate.handleHeartbeat(this, msg);
   }
 
   private _handleDifficultyUpdate(msg: BlockchainNodeMessage) {
-    if (msg.difficulty && msg.difficulty !== this.difficulty) {
-      if (this.mining) {
-        this.stopMining();
-      }
-      this.difficulty = msg.difficulty;
-      localStorage.setItem('networkDifficulty', msg.difficulty.toString());
-      this._emit('difficulty');
-      addActivityLog('network', `Difficulty updated to ${msg.difficulty} by ${msg.from}`);
-    }
+    NodePrivate.handleDifficultyUpdate(this, msg);
   }
 
   private async _verifyTransaction(tx: Transaction): Promise<boolean> {
-    try {
-      // Check for basic transaction structure
-      if (!tx.id || !tx.type || !tx.from || tx.timestamp === undefined) {
-        addActivityLog('security', `Transaction ${tx.id} rejected - missing required fields`);
-        return false;
-      }
-
-      // Check signature
-      if (!tx.signature || !tx.publicKey) {
-        addActivityLog('security', `Transaction ${tx.id} rejected - missing signature`);
-        return false;
-      }
-
-      // Verify signature
-      const txData = `${tx.type}|${tx.from}|${tx.to}|${tx.amount}|${JSON.stringify(tx.payload)}|${tx.timestamp}`;
-      const isValidSignature = await verify(txData, tx.signature, tx.publicKey);
-      if (!isValidSignature) {
-        addActivityLog('security', `Transaction ${tx.id} rejected - invalid signature`);
-        return false;
-      }
-
-      // Check for replay attacks (transaction too old)
-      const now = Date.now();
-      if (now - tx.timestamp > 60 * 60 * 1000) { // 1 hour
-        addActivityLog('security', `Transaction ${tx.id} rejected - too old (replay attack)`);
-        return false;
-      }
-
-      // Check for duplicate transactions
-      const isDuplicate = this.chain.some(block =>
-        block.transactions.some(existingTx =>
-          existingTx.id === tx.id ||
-          (existingTx.from === tx.from &&
-            existingTx.to === tx.to &&
-            existingTx.amount === tx.amount &&
-            existingTx.timestamp === tx.timestamp)
-        )
-      );
-      if (isDuplicate) {
-        addActivityLog('security', `Transaction ${tx.id} rejected - duplicate transaction`);
-        return false;
-      }
-
-      // Check transaction-specific rules
-      if (tx.type === 'transfer') {
-        // Check for negative amounts
-        if (tx.amount < 0) {
-          addActivityLog('security', `Transaction ${tx.id} rejected - negative amount`);
-          return false;
-        }
-
-        // Check sender balance (basic check)
-        if (this.balances[tx.from] !== undefined && this.balances[tx.from] < tx.amount) {
-          addActivityLog('security', `Transaction ${tx.id} rejected - insufficient balance`);
-          return false;
-        }
-      }
-
-      // Check payload for malicious content
-      if (tx.payload && typeof tx.payload === 'string') {
-        const maliciousPatterns = [/<script/i, /javascript:/i, /on\w+=/i];
-        if (maliciousPatterns.some(pattern => pattern.test(tx.payload))) {
-          addActivityLog('security', `Transaction ${tx.id} rejected - malicious payload detected`);
-          return false;
-        }
-      }
-
-      return true;
-    } catch (error) {
-      addActivityLog('security', `Transaction ${tx.id} rejected - verification error: ${error}`);
-      return false;
-    }
+    return NodePrivate.verifyTransaction(this, tx);
   }
 
   private async _handleTransaction(msg: BlockchainNodeMessage): Promise<void> {
-    if (!msg.tx || this.mempool.find(t => t.id === msg.tx!.id)) {
-      return;
-    }
-
-    // Verify transaction signature
-    const isValid = await this._verifyTransaction(msg.tx);
-    if (!isValid) {
-      addActivityLog('security', `Node ${this.id} rejected invalid transaction ${msg.tx.id} from ${msg.from}`);
-      return;
-    }
-
-    this.mempool.push(msg.tx);
-    this._emit('mempool');
-    this.bus.broadcast(msg);
-    addActivityLog('transaction', `Node ${this.id} received valid transaction ${msg.tx.id} from ${msg.from}`);
+    await NodePrivate.handleTransaction(this, msg);
   }
 
   private _handleNewBlock(msg: BlockchainNodeMessage) {
-    if (msg.block) {
-      this._validateAndProposeBlock(msg.block);
-    }
-    addActivityLog('network', `Node ${this.id} received new block ${msg.block!.hash} from ${msg.from}`);
+    NodePrivate.handleNewBlock(this, msg);
   }
 
   private async _validateAndProposeBlock(block: Block): Promise<void> {
-    try {
-      // Check block structure
-      if (!block.hash || !block.prevHash || block.index === undefined) {
-        addActivityLog('security', `Block ${block.hash} rejected - missing required fields`);
-        return;
-      }
-
-      // Verify block hash
-      const raw = `${block.index}|${block.prevHash}|${block.timestamp}|${block.nonce}|${JSON.stringify(block.transactions)}`;
-      const expectedHash = await sha256(raw);
-
-      if (expectedHash !== block.hash) {
-        addActivityLog('security', `Block ${block.hash} rejected - invalid hash`);
-        return;
-      }
-
-      // Check previous hash
-      if (this.chain.length > 0) {
-        const lastBlock = this.chain[this.chain.length - 1];
-        if (block.prevHash !== lastBlock.hash) {
-          addActivityLog('security', `Block ${block.hash} rejected - invalid previous hash`);
-          return;
-        }
-      }
-
-      // Check difficulty
-      const target = '0'.repeat(block.difficulty);
-      if (!block.hash.startsWith(target)) {
-        addActivityLog('security', `Block ${block.hash} rejected - insufficient difficulty`);
-        return;
-      }
-
-      // Verify all transactions in the block
-      for (const tx of block.transactions) {
-        const isValid = await this._verifyTransaction(tx);
-        if (!isValid) {
-          addActivityLog('security', `Block ${block.hash} rejected - contains invalid transaction ${tx.id}`);
-          return;
-        }
-      }
-
-      addActivityLog('validation', `Block ${block.hash} validation successful`);
-      this.consensus.propose(block);
-    } catch (error) {
-      addActivityLog('security', `Block ${block.hash} rejected - validation error: ${error}`);
-    }
+    await NodePrivate.validateAndProposeBlock(this, block);
   }
 
   private _handleBlockchainReset(msg: BlockchainNodeMessage) {
-    if (msg.from === this.id) return; // Don't reset if we initiated it
-
-    if (this.mining) {
-      this.stopMining();
-    }
-
-    this._resetLocalState();
-    this._emitStateChanges();
-    addActivityLog('network', `Blockchain reset by ${msg.from}`);
+    NodePrivate.handleBlockchainReset(this, msg);
   }
 
   private _resetLocalState() {
-    this.chain = [];
-    this.mempool = [];
-    this.contracts = {};
-    this.balances = { [this.id]: 100 };
-    this.difficulty = 4;
-
-    localStorage.removeItem('chain');
-    localStorage.removeItem('balances');
-    localStorage.setItem('networkDifficulty', '4');
+    NodePrivate.resetLocalState(this);
   }
 
   private _emitStateChanges() {
-    this._emit('chain');
-    this._emit('mempool');
-    this._emit('balances');
-    this._emit('contracts');
+    NodePrivate.emitStateChanges(this);
   }
 
   private _handleVote(msg: BlockchainNodeMessage) {
-    if (msg.block) {
-      this.consensus.handleMessage({
-        type: 'VOTE',
-        from: msg.from,
-        blockHash: msg.block.hash,
-        block: msg.block
-      });
-    }
+    NodePrivate.handleVote(this, msg);
   }
 
   _onBusMessage(msg: BlockchainNodeMessage) {
-    if (!msg || !msg.type || !msg.from) return;
-
-    const handlers: { [key: string]: (msg: BlockchainNodeMessage) => void } = {
-      'HELLO': this._handleHello.bind(this),
-      'HELLO_ACK': this._handleHelloAck.bind(this),
-      'GOODBYE': this._handleGoodbye.bind(this),
-      'HEARTBEAT': this._handleHeartbeat.bind(this),
-      'DIFFICULTY_UPDATE': this._handleDifficultyUpdate.bind(this),
-      'TX': this._handleTransaction.bind(this),
-      'NEW_BLOCK': this._handleNewBlock.bind(this),
-      'BLOCKCHAIN_RESET': this._handleBlockchainReset.bind(this),
-      'VOTE': this._handleVote.bind(this)
-    };
-
-    const handler = handlers[msg.type];
-    if (handler) {
-      handler(msg);
-    }
+    NodePrivate.onBusMessage(this, msg);
   }
 }

--- a/src/content/blockhain-simulator/services/node/private.ts
+++ b/src/content/blockhain-simulator/services/node/private.ts
@@ -1,0 +1,319 @@
+import { generateKeyPair, sign, sha256, verify, clone } from '../../utils/crypto';
+import { Transaction } from '../../models/Transaction';
+import { Block } from '../../models/Block';
+import { ContractEngine } from '../ContractEngine';
+import { PoWMiner } from '../PoWMiner';
+import { addActivityLog } from '../../utils/log';
+import type { BlockchainNode } from '../BlockchainNode';
+import type { BlockchainNodeMessage } from '../BlockchainNode';
+
+export function emit(node: BlockchainNode, evt: string) {
+    for (const f of node.listeners[evt]) f(node.getState());
+}
+
+export function loadOrGenerateKeys(node: BlockchainNode): { publicKey: string; privateKey: string } {
+    const stored = localStorage.getItem(`keys_${node.id}`);
+    if (stored) {
+        return JSON.parse(stored);
+    }
+    const keyPair = generateKeyPair();
+    localStorage.setItem(`keys_${node.id}`, JSON.stringify(keyPair));
+    return keyPair;
+}
+
+export async function signTransaction(node: BlockchainNode, tx: Transaction): Promise<void> {
+    const txData = `${tx.type}|${tx.from}|${tx.to}|${tx.amount}|${JSON.stringify(tx.payload)}|${tx.timestamp}`;
+    tx.signature = await sign(txData, node.keyPair.privateKey);
+    tx.publicKey = node.keyPair.publicKey;
+}
+
+export async function mineLoop(node: BlockchainNode, diff: number) {
+    while (node.mining && !node.minerAbort.killed) {
+        if (node.mempool.length === 0) {
+            await new Promise(r => setTimeout(r, 500));
+            continue;
+        }
+        const block = new Block({
+            index: node.chain.length,
+            prevHash: node.chain.length ? node.chain[node.chain.length - 1].hash : 'GENESIS',
+            proposer: node.id,
+            difficulty: diff,
+            transactions: clone(node.mempool),
+        });
+        const ok = await PoWMiner.mine(block, diff, node.minerAbort);
+        if (!ok) {
+            if (node.mining && node.minerAbort.killed) {
+                node.minerAbort = { killed: false };
+                continue;
+            }
+            break;
+        }
+        node.bus.broadcast({ type: 'NEW_BLOCK', from: node.id, block });
+        node.consensus.propose(block);
+        await new Promise(r => setTimeout(r, 200));
+    }
+}
+
+export async function commitBlock(node: BlockchainNode, block: Block): Promise<void> {
+    if (node.chain.find(b => b.hash === block.hash)) return;
+    for (const tx of block.transactions) {
+        const isValid = await verifyTransaction(node, tx);
+        if (!isValid) {
+            addActivityLog('security', `Block ${block.hash} rejected - contains invalid transaction ${tx.id}`);
+            return;
+        }
+    }
+    if (node.mining) {
+        node.minerAbort.killed = true;
+    }
+    const ids = new Set(block.transactions.map(t => t.id));
+    node.mempool = node.mempool.filter(t => !ids.has(t.id));
+    for (const tx of block.transactions) {
+        if (tx.type === 'deploy') {
+            const c = ContractEngine.deploy(tx.payload);
+            node.contracts[c.address] = c;
+            addActivityLog('contract', `Deployed contract ${c.address} with code: ${tx.payload.slice(0, 20)}...`);
+        } else if (tx.type === 'call') {
+            const c = node.contracts[tx.to];
+            if (c) ContractEngine.call(c, tx.payload, node.contracts);
+            addActivityLog('contract', `Called contract ${tx.to} with input: ${JSON.stringify(tx.payload)}`);
+        } else if (tx.type === 'transfer') {
+            if (!node.balances[tx.from]) node.balances[tx.from] = 0;
+            if (!node.balances[tx.to]) node.balances[tx.to] = 0;
+            if (node.balances[tx.from] >= tx.amount) {
+                node.balances[tx.from] -= tx.amount;
+                node.balances[tx.to] += tx.amount;
+            }
+        }
+    }
+    node.chain.push(block);
+    if (node.chain.length > 100) {
+        addActivityLog('network', `Node ${node.id} trimmed blockchain to last 100 blocks`);
+        node.chain = node.chain.slice(-100);
+    }
+    localStorage.setItem('chain', JSON.stringify(node.chain));
+    localStorage.setItem('balances', JSON.stringify(node.balances));
+    emit(node, 'chain');
+    emit(node, 'mempool');
+    emit(node, 'balances');
+    emit(node, 'contracts');
+    if (node.mining) {
+        node.minerAbort = { killed: false };
+    }
+}
+
+export function handleHello(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    node.peers.add(msg.from);
+    node.peerLastSeen.set(msg.from, Date.now());
+    emit(node, 'peers');
+    if (msg.from !== node.id) {
+        node.bus.broadcast({ type: 'HELLO_ACK', from: node.id, to: msg.from });
+    }
+    addActivityLog('peer', `New peer ${msg.from} joined the network`);
+}
+
+export function handleHelloAck(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    if (msg.to === node.id) {
+        node.peers.add(msg.from);
+        node.peerLastSeen.set(msg.from, Date.now());
+        emit(node, 'peers');
+    }
+    addActivityLog('network', `Node ${node.id} acknowledged peer ${msg.from}`);
+}
+
+export function handleGoodbye(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    node.peers.delete(msg.from);
+    node.peerLastSeen.delete(msg.from);
+    emit(node, 'peers');
+    addActivityLog('peer', `Peer ${msg.from} left the network`);
+}
+
+export function handleHeartbeat(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    node.peers.add(msg.from);
+    node.peerLastSeen.set(msg.from, Date.now());
+}
+
+export function handleDifficultyUpdate(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    if (msg.difficulty && msg.difficulty !== node.difficulty) {
+        if (node.mining) {
+            node.stopMining();
+        }
+        node.difficulty = msg.difficulty;
+        localStorage.setItem('networkDifficulty', msg.difficulty.toString());
+        emit(node, 'difficulty');
+        addActivityLog('network', `Difficulty updated to ${msg.difficulty} by ${msg.from}`);
+    }
+}
+
+export async function verifyTransaction(node: BlockchainNode, tx: Transaction): Promise<boolean> {
+    try {
+        if (!tx.id || !tx.type || !tx.from || tx.timestamp === undefined) {
+            addActivityLog('security', `Transaction ${tx.id} rejected - missing required fields`);
+            return false;
+        }
+        if (!tx.signature || !tx.publicKey) {
+            addActivityLog('security', `Transaction ${tx.id} rejected - missing signature`);
+            return false;
+        }
+        const txData = `${tx.type}|${tx.from}|${tx.to}|${tx.amount}|${JSON.stringify(tx.payload)}|${tx.timestamp}`;
+        const isValidSignature = await verify(txData, tx.signature, tx.publicKey);
+        if (!isValidSignature) {
+            addActivityLog('security', `Transaction ${tx.id} rejected - invalid signature`);
+            return false;
+        }
+        const now = Date.now();
+        if (now - tx.timestamp > 60 * 60 * 1000) {
+            addActivityLog('security', `Transaction ${tx.id} rejected - too old (replay attack)`);
+            return false;
+        }
+        const isDuplicate = node.chain.some(block =>
+            block.transactions.some(existingTx =>
+                existingTx.id === tx.id ||
+                (existingTx.from === tx.from && existingTx.to === tx.to && existingTx.amount === tx.amount && existingTx.timestamp === tx.timestamp)
+            )
+        );
+        if (isDuplicate) {
+            addActivityLog('security', `Transaction ${tx.id} rejected - duplicate transaction`);
+            return false;
+        }
+        if (tx.type === 'transfer') {
+            if (tx.amount < 0) {
+                addActivityLog('security', `Transaction ${tx.id} rejected - negative amount`);
+                return false;
+            }
+            if (node.balances[tx.from] !== undefined && node.balances[tx.from] < tx.amount) {
+                addActivityLog('security', `Transaction ${tx.id} rejected - insufficient balance`);
+                return false;
+            }
+        }
+        if (tx.payload && typeof tx.payload === 'string') {
+            const maliciousPatterns = [/<script/i, /javascript:/i, /on\w+=/i];
+            if (maliciousPatterns.some(pattern => pattern.test(tx.payload))) {
+                addActivityLog('security', `Transaction ${tx.id} rejected - malicious payload detected`);
+                return false;
+            }
+        }
+        return true;
+    } catch (error) {
+        addActivityLog('security', `Transaction ${tx.id} rejected - verification error: ${error}`);
+        return false;
+    }
+}
+
+export async function handleTransaction(node: BlockchainNode, msg: BlockchainNodeMessage): Promise<void> {
+    if (!msg.tx || node.mempool.find(t => t.id === msg.tx!.id)) {
+        return;
+    }
+    const isValid = await verifyTransaction(node, msg.tx);
+    if (!isValid) {
+        addActivityLog('security', `Node ${node.id} rejected invalid transaction ${msg.tx.id} from ${msg.from}`);
+        return;
+    }
+    node.mempool.push(msg.tx);
+    emit(node, 'mempool');
+    node.bus.broadcast(msg);
+    addActivityLog('transaction', `Node ${node.id} received valid transaction ${msg.tx.id} from ${msg.from}`);
+}
+
+export function handleNewBlock(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    if (msg.block) {
+        validateAndProposeBlock(node, msg.block);
+    }
+    addActivityLog('network', `Node ${node.id} received new block ${msg.block!.hash} from ${msg.from}`);
+}
+
+export async function validateAndProposeBlock(node: BlockchainNode, block: Block): Promise<void> {
+    try {
+        if (!block.hash || !block.prevHash || block.index === undefined) {
+            addActivityLog('security', `Block ${block.hash} rejected - missing required fields`);
+            return;
+        }
+        const raw = `${block.index}|${block.prevHash}|${block.timestamp}|${block.nonce}|${JSON.stringify(block.transactions)}`;
+        const expectedHash = await sha256(raw);
+        if (expectedHash !== block.hash) {
+            addActivityLog('security', `Block ${block.hash} rejected - invalid hash`);
+            return;
+        }
+        if (node.chain.length > 0) {
+            const lastBlock = node.chain[node.chain.length - 1];
+            if (block.prevHash !== lastBlock.hash) {
+                addActivityLog('security', `Block ${block.hash} rejected - invalid previous hash`);
+                return;
+            }
+        }
+        const target = '0'.repeat(block.difficulty);
+        if (!block.hash.startsWith(target)) {
+            addActivityLog('security', `Block ${block.hash} rejected - insufficient difficulty`);
+            return;
+        }
+        for (const tx of block.transactions) {
+            const isValid = await verifyTransaction(node, tx);
+            if (!isValid) {
+                addActivityLog('security', `Block ${block.hash} rejected - contains invalid transaction ${tx.id}`);
+                return;
+            }
+        }
+        addActivityLog('validation', `Block ${block.hash} validation successful`);
+        node.consensus.propose(block);
+    } catch (error) {
+        addActivityLog('security', `Block ${block.hash} rejected - validation error: ${error}`);
+    }
+}
+
+export function handleBlockchainReset(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    if (msg.from === node.id) return;
+    if (node.mining) {
+        node.stopMining();
+    }
+    resetLocalState(node);
+    emitStateChanges(node);
+    addActivityLog('network', `Blockchain reset by ${msg.from}`);
+}
+
+export function resetLocalState(node: BlockchainNode) {
+    node.chain = [];
+    node.mempool = [];
+    node.contracts = {};
+    node.balances = { [node.id]: 100 };
+    node.difficulty = 4;
+    localStorage.removeItem('chain');
+    localStorage.removeItem('balances');
+    localStorage.setItem('networkDifficulty', '4');
+}
+
+export function emitStateChanges(node: BlockchainNode) {
+    emit(node, 'chain');
+    emit(node, 'mempool');
+    emit(node, 'balances');
+    emit(node, 'contracts');
+}
+
+export function handleVote(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    if (msg.block) {
+        node.consensus.handleMessage({
+            type: 'VOTE',
+            from: msg.from,
+            blockHash: msg.block.hash,
+            block: msg.block,
+        });
+    }
+}
+
+export function onBusMessage(node: BlockchainNode, msg: BlockchainNodeMessage) {
+    if (!msg || !msg.type || !msg.from) return;
+    const handlers: { [key: string]: (node: BlockchainNode, msg: BlockchainNodeMessage) => void | Promise<void> } = {
+        'HELLO': handleHello,
+        'HELLO_ACK': handleHelloAck,
+        'GOODBYE': handleGoodbye,
+        'HEARTBEAT': handleHeartbeat,
+        'DIFFICULTY_UPDATE': handleDifficultyUpdate,
+        'TX': handleTransaction,
+        'NEW_BLOCK': handleNewBlock,
+        'BLOCKCHAIN_RESET': handleBlockchainReset,
+        'VOTE': handleVote,
+    };
+    const handler = handlers[msg.type];
+    if (handler) {
+        (handler as any)(node, msg);
+    }
+}

--- a/src/content/blockhain-simulator/services/node/public.ts
+++ b/src/content/blockhain-simulator/services/node/public.ts
@@ -1,0 +1,197 @@
+import { sign } from '../../utils/crypto';
+import { Transaction } from '../../models/Transaction';
+import { Block } from '../../models/Block';
+import { sha256 } from '../../utils/crypto';
+import type { BlockchainNode } from '../BlockchainNode';
+import { emit } from './private';
+
+export async function createTx(node: BlockchainNode, payload: any, to = '', amount = 0): Promise<string> {
+    const tx = new Transaction({
+        type: 'transfer',
+        from: node.id,
+        payload,
+        to,
+        amount,
+    });
+    await node._signTransaction(tx);
+    node.mempool.push(tx);
+    emit(node, 'mempool');
+    node.bus.broadcast({ type: 'TX', from: node.id, tx });
+    return tx.id;
+}
+
+export async function deployContract(node: BlockchainNode, code: string): Promise<string> {
+    const tx = new Transaction({
+        type: 'deploy',
+        from: node.id,
+        payload: code,
+        to: '',
+    });
+    await node._signTransaction(tx);
+    node.mempool.push(tx);
+    emit(node, 'mempool');
+    node.bus.broadcast({ type: 'TX', from: node.id, tx });
+    return tx.id;
+}
+
+export async function callContract(node: BlockchainNode, address: string, input: any): Promise<string> {
+    const tx = new Transaction({
+        type: 'call',
+        from: node.id,
+        to: address,
+        payload: input,
+    });
+    await node._signTransaction(tx);
+    node.mempool.push(tx);
+    emit(node, 'mempool');
+    node.bus.broadcast({ type: 'TX', from: node.id, tx });
+    return tx.id;
+}
+
+export function updateDifficulty(node: BlockchainNode, newDifficulty: number) {
+    node.difficulty = newDifficulty;
+    localStorage.setItem('networkDifficulty', newDifficulty.toString());
+    node.bus.broadcast({ type: 'DIFFICULTY_UPDATE', from: node.id, difficulty: newDifficulty });
+}
+
+export function startMining(node: BlockchainNode, difficulty?: number) {
+    if (node.mining) return;
+    const targetDifficulty = difficulty || node.difficulty;
+    if (targetDifficulty !== node.difficulty) {
+        updateDifficulty(node, targetDifficulty);
+    }
+    node.mining = true;
+    node.minerAbort = { killed: false };
+    node._mineLoop(targetDifficulty);
+}
+
+export function stopMining(node: BlockchainNode) {
+    if (node.mining) {
+        node.minerAbort.killed = true;
+        node.mining = false;
+    }
+}
+
+export function resetBlockchain(node: BlockchainNode) {
+    if (node.mining) {
+        stopMining(node);
+    }
+    node.chain = [];
+    node.mempool = [];
+    node.contracts = {};
+    localStorage.removeItem('chain');
+    localStorage.removeItem('networkDifficulty');
+    node.difficulty = 4;
+    localStorage.setItem('networkDifficulty', '4');
+    node.bus.broadcast({ type: 'BLOCKCHAIN_RESET', from: node.id });
+    emit(node, 'chain');
+    emit(node, 'mempool');
+}
+
+export function proposeValidator(node: BlockchainNode, nodeId: string) {
+    node.bus.broadcast({ type: 'PROPOSE_VALIDATOR', from: node.id, nodeId });
+}
+
+export function voteValidator(node: BlockchainNode, nodeId: string, approve: boolean) {
+    node.bus.broadcast({ type: 'VOTE_VALIDATOR', from: node.id, nodeId, approve });
+}
+
+export async function createMaliciousTx(node: BlockchainNode, type: 'invalid_signature' | 'double_spend' | 'invalid_balance' | 'malformed_data' | 'replay_attack'): Promise<string> {
+    let tx: Transaction;
+    switch (type) {
+        case 'invalid_signature':
+            tx = new Transaction({
+                type: 'transfer',
+                from: node.id,
+                to: Array.from(node.peers)[1] || 'unknown',
+                amount: 10,
+                payload: 'Malicious transaction with invalid signature',
+            });
+            tx.signature = await sign(`fake_data`, 'wrong_private_key');
+            tx.publicKey = node.keyPair.publicKey;
+            break;
+        case 'double_spend':
+            tx = new Transaction({
+                type: 'transfer',
+                from: node.id,
+                to: Array.from(node.peers)[1] || 'unknown',
+                amount: node.balances[node.id] + 100,
+                payload: 'Double spend attempt',
+            });
+            await node._signTransaction(tx);
+            break;
+        case 'invalid_balance':
+            tx = new Transaction({
+                type: 'transfer',
+                from: node.id,
+                to: Array.from(node.peers)[1] || 'unknown',
+                amount: -50,
+                payload: 'Invalid negative amount',
+            });
+            await node._signTransaction(tx);
+            break;
+        case 'malformed_data':
+            tx = new Transaction({
+                type: 'transfer',
+                from: node.id,
+                to: Array.from(node.peers)[1] || 'unknown',
+                amount: 10,
+                payload: { malicious: true, script: '<script>alert("xss")</script>' },
+            });
+            await node._signTransaction(tx);
+            tx.payload = null;
+            break;
+        case 'replay_attack':
+            const existingTx = node.chain.flatMap(block => block.transactions)[0];
+            if (existingTx) {
+                tx = new Transaction({
+                    type: existingTx.type,
+                    from: existingTx.from,
+                    to: existingTx.to,
+                    amount: existingTx.amount,
+                    payload: existingTx.payload,
+                });
+                tx.signature = existingTx.signature;
+                tx.publicKey = existingTx.publicKey;
+                tx.timestamp = existingTx.timestamp;
+            } else {
+                tx = new Transaction({
+                    type: 'transfer',
+                    from: node.id,
+                    to: Array.from(node.peers)[1] || 'unknown',
+                    amount: 10,
+                    payload: 'Replay attack attempt',
+                });
+                await node._signTransaction(tx);
+            }
+            break;
+        default:
+            throw new Error(`Unknown malicious transaction type: ${type}`);
+    }
+    node.bus.broadcast({ type: 'TX', from: node.id, tx });
+    return tx.id;
+}
+
+export async function createMaliciousBlock(node: BlockchainNode): Promise<void> {
+    if (!node.mining) {
+        return;
+    }
+    const maliciousTx = new Transaction({
+        type: 'transfer',
+        from: 'fake_node',
+        to: node.id,
+        amount: 1000000,
+        payload: 'Malicious block creation',
+    });
+    const block = new Block({
+        index: node.chain.length,
+        prevHash: 'INVALID_PREV_HASH',
+        proposer: node.id,
+        difficulty: 1,
+        transactions: [maliciousTx],
+    });
+    block.hash = await sha256('malicious_block_' + Date.now());
+    block.nonce = 0;
+    node.bus.broadcast({ type: 'NEW_BLOCK', from: node.id, block });
+}
+


### PR DESCRIPTION
## Summary
- split large `BlockchainNode` methods into helper modules
- move public actions to `services/node/public.ts`
- move internal logic to `services/node/private.ts`
- delegate methods in `BlockchainNode` to the new modules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6857aff15c208325b7bac7cb6f518e86